### PR TITLE
handle comment by ignoring it

### DIFF
--- a/src/xml/mod.rs
+++ b/src/xml/mod.rs
@@ -520,6 +520,7 @@ fn read_xml_loop<R: BufRead>(
                 }
             }
             Event::Decl(_) => {}
+            Event::Comment(_) => {}
             _ => {
                 return Err(ReadErrorWrapper::new(
                     ReadError::UnhandledEvent(QuickXmlEventType::from(&event)),


### PR DESCRIPTION
Resolves #8 by ignoring comments when they are found.

The previous behavior would to panic on an unhandled event.